### PR TITLE
Added wsgi.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,7 +203,7 @@ About This Repo
 
 The Hosting Instance
 ====================
-NoLCAT is a containerized application: it exists within a Docker container which is built on an AWS EC2 instance. The instance, a t3.2xlarge containing a virtual Linux server, contains files with Docker build instructions and private information that cannot be committed to GitHub.
+NoLCAT is a containerized application: it exists within a Docker container which is built on an AWS EC2 instance. The host instance, a Linux-based t3.2xlarge, contains files with Docker build instructions and private information that cannot be committed to GitHub.
 
 Working with the Web Server
 ---------------------------
@@ -212,7 +212,7 @@ The public IP address used to access the web app is ultimately that of the insta
 
 Working with MySQL
 ------------------
-The MySQL program used by NoLCAT is in the instance; as a result, the MySQL command line can be accessed from the instance command line.
+The instance can access the external MySQL database server, which serves as the RDBMS for NoLCAT. The MySQL command line can be accessed from the instance command line.
 
 Encodings and File Types
 ========================

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,19 @@ Branch: Configure Flask-User
 About This Repo
 ***************
 
+The Hosting Instance
+====================
+NoLCAT is a containerized application: it exists within a Docker container which is built on an AWS EC2 instance. The instance, a t3.2xlarge containing a virtual Linux server, contains files with Docker build instructions and private information that cannot be committed to GitHub.
+
+Working with the Web Server
+---------------------------
+NoLCAT is a web application, meaning the program is accessed through the internet and controlled through a web browser. It uses Flask as the web framework, Gunicorn as the WSGI (web service gateway interface), and nginx as the web server. Gunicorn and nginx are added to the instance as part of the Docker build process and connect to the overall codebase through the "nolcat/wsgi.py" file, which contains an instantiated Flask object.
+The public IP address used to access the web app is ultimately that of the instance.
+
+Working with MySQL
+------------------
+The MySQL program used by NoLCAT is in the instance; as a result, the MySQL command line can be accessed from the instance command line.
+
 Encodings and File Types
 ========================
 

--- a/nolcat/app.py
+++ b/nolcat/app.py
@@ -80,39 +80,15 @@ def create_app():
 
     #Section: Create Homepage and Register Other Blueprints
     #Subsection: Import Blueprints
-    # Various environments seem to want different paths to the blueprints. AWS prefers `nolcat`, throwing a `ValueError: attempted relative import beyond top-level package` at `..nolcat` and `ModuleNotFoundError: No module named 'nolcat.nolcat'` at `.nolcat`, but all three are kept for ease of deployment.
-    try:
-        from nolcat import annual_stats
-        from nolcat import ingest_usage
-        from nolcat import initialization
-        from nolcat import login
-        from nolcat import view_resources
-        from nolcat import view_sources
-        from nolcat import view_usage
-        from nolcat import view_vendors
-        logging.debug("Blueprints imported from `nolcat`")
-    except (ValueError, ModuleNotFoundError):
-        try:
-            from .nolcat import annual_stats
-            from .nolcat import ingest_usage
-            from .nolcat import initialization
-            from .nolcat import login
-            from .nolcat import view_resources
-            from .nolcat import view_sources
-            from .nolcat import view_usage
-            from .nolcat import view_vendors
-            logging.debug("Blueprints imported from `.nolcat`")
-        except (ValueError, ModuleNotFoundError):
-            from ..nolcat import annual_stats
-            from ..nolcat import ingest_usage
-            from ..nolcat import initialization
-            from ..nolcat import login
-            from ..nolcat import view_resources
-            from ..nolcat import view_sources
-            from ..nolcat import view_usage
-            from ..nolcat import view_vendors
-            logging.debug("Blueprints imported from `..nolcat`")
-            # The program would need to exit here no matter what; letting it crash provides a full stack trace
+    from nolcat import annual_stats
+    from nolcat import ingest_usage
+    from nolcat import initialization
+    from nolcat import login
+    from nolcat import view_resources
+    from nolcat import view_sources
+    from nolcat import view_usage
+    from nolcat import view_vendors
+    logging.debug("Blueprints imported from `nolcat`")
 
     #Subsection: Register Blueprints
     app.register_blueprint(annual_stats.bp)

--- a/nolcat/app.py
+++ b/nolcat/app.py
@@ -78,30 +78,33 @@ def create_app():
             from .models import UsageData
             db.create_all()
 
-    #Section: Create Homepage and Register Other Blueprints
-    #Subsection: Import Blueprints
+    #Section: Register Blueprints
     from nolcat import annual_stats
-    from nolcat import ingest_usage
-    from nolcat import initialization
-    from nolcat import login
-    from nolcat import view_resources
-    from nolcat import view_sources
-    from nolcat import view_usage
-    from nolcat import view_vendors
-    logging.debug("Blueprints imported from `nolcat`")
-
-    #Subsection: Register Blueprints
     app.register_blueprint(annual_stats.bp)
-    app.register_blueprint(ingest_usage.bp)
-    app.register_blueprint(initialization.bp)
-    app.register_blueprint(login.bp)
-    app.register_blueprint(view_resources.bp)
-    app.register_blueprint(view_sources.bp)
-    app.register_blueprint(view_usage.bp)
-    app.register_blueprint(view_vendors.bp)
-    logging.debug("Blueprints registered")
 
-    #Subsection: Create Homepage Route
+    from nolcat import ingest_usage
+    app.register_blueprint(ingest_usage.bp)
+
+    from nolcat import initialization
+    app.register_blueprint(initialization.bp)
+
+    from nolcat import login
+    app.register_blueprint(login.bp)
+
+    from nolcat import view_resources
+    app.register_blueprint(view_resources.bp)
+
+    from nolcat import view_sources
+    app.register_blueprint(view_sources.bp)
+
+    from nolcat import view_usage
+    app.register_blueprint(view_usage.bp)
+
+    from nolcat import view_vendors
+    app.register_blueprint(view_vendors.bp)
+    logging.debug("Blueprints imported and registered")
+
+    #Section: Create Homepage Route
     @app.route('/')
     def homepage():
         """Returns the homepage in response to web app root requests."""

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+"""Provides and app object for gunicorn, etc."""
+
+from nolcat.app import create_app
+app = create_app()

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,4 +1,4 @@
-"""Provides and app object for gunicorn, etc."""
+"""Provides an app object for Gunicorn, etc."""
 
 from nolcat.app import create_app
 app = create_app()


### PR DESCRIPTION
Committed the wsgi file to its proper place in the repo. Updated nolcat Dockerfile to set the WORKDIR=/nolcat, and to have gunicorn locate the wsgi module at nolcat.wsgi. wsgi.py now looks in wsgi.app for the create_app function.

In other words, deployed application no longer uses / as its root, and instead uses /nolcat.

This resolves the inability to launch the update_for_testing branch.